### PR TITLE
using PyLong_FromUnsignedLongLong() avoids negative values in ethtool…

### DIFF
--- a/python-ethtool/ethtool.c
+++ b/python-ethtool/ethtool.c
@@ -567,7 +567,7 @@ static PyObject *get_stats(PyObject *self __unused, PyObject *args)
 		goto out;
 	}
 	for (i = 0; i < n_stats; i++) {
-		objval = PyInt_FromLong(stats->data[i]);
+		objval = PyLong_FromUnsignedLongLong(stats->data[i]);
 		if (objval == NULL)
 			goto out;
 		buf = (char *)&strings->data[i * ETH_GSTRING_LEN];


### PR DESCRIPTION
ethtool statistics correspond to unsigned long long type and get_stats is using PyInt_FromLong()  provoking negative values as shown in the picture below (right: python-ethtool with negative values; left: ethtool statistics with its corresponding unsigned long long values). 

![screenshot_1](https://user-images.githubusercontent.com/6576940/57181565-d38e1f80-6e95-11e9-8e03-19d3ccb043c1.png)

Using PyLong_FromUnsignedLongLong() fixes the negative values and resembles to ethtool behaviour (starting again from 0 when reaching max value of a specific statistics item) 